### PR TITLE
feat: switch password store to chrome internal store

### DIFF
--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -81,6 +81,7 @@ func (a URLScreenshotter) execAllocator(parent context.Context) (context.Context
 	options = append(options, chromedp.Flag("disable-features", "VizDisplayCompositor"))
 	options = append(options, chromedp.Flag("incognito", true))
 	options = append(options, chromedp.Flag("ignore-certificate-errors", true))
+	options = append(options, chromedp.Flag("password-store", "basic"))
 
 	return chromedp.NewExecAllocator(parent, options...)
 }


### PR DESCRIPTION
Hi there,

Thanks for maintaining this aquatone fork. During a recent engagement I ran into a situation, where aquatone was trying to unlook the Linux Keyring used by Chrome. As this failed no screenshots were taken.

My research showed that changing back to the "traditional" internal password store, this error can be mitigated.

As aquatone does not handle or store passwords, this should not be an issue.

