### PR TITLE
Fix for nmap HTTP service parsing

### DIFF
--- a/parsers/nmap.go
+++ b/parsers/nmap.go
@@ -45,12 +45,14 @@ func (p *NmapParser) hostToURLs(host nmap.Host) []string {
 		}
 
 		var protocol string
-		if port.Service.Name == "ssl" {
-			protocol = "https"
-		} else if port.Service.Tunnel == "ssl" && (port.Service.Name != "smtp" && port.Service.Name != "imap" && port.Service.Name != "pop3") {
-			protocol = "https"
-		} else if port.Service.Name == "http" || port.Service.Name == "http-alt" {
-			protocol = "http"
+		if port.Protocol == "tcp" && (port.Service.Name == "http" || port.Service.Name == "http-alt") {
+			if port.Service.Tunnel == "ssl" {
+				protocol = "https"
+			} else {
+				protocol = "http"
+			}
+		} else {
+			continue
 		}
 
 		if len(host.Hostnames) > 0 {


### PR DESCRIPTION
Due to a bug, aquatone tried to scan every identified service of a nmap scan (even if it was a UDP service). Now, only TCP services identified as "http" or "http-alt" are scanned.

Can be reproduced by, e.g., listening on localhost on both UDP and TCP:

```
ncat -lvknu 127.0.0.1 9100 </dev/urandom
ncat -lvkn 127.0.0.1 9100 </dev/urandom
```

After that use aquatone with a nmap XML file:

```
sudo nmap -sU -p9100 127.0.0.1 -oX - | aquatone -nmap
```

In this case, the nmap scan triggers the connection to port 9100 UDP, finds the port to be open and outputs it as an XML. aquatone reads the nmap XML file, initiates a connection to 9100 TCP and sends a HTTP request.

I only realized this because this exact port is normally used by printers to print the exact data received. So the HTTP request was printed a few sheets of paper on a recent network scan ;-)